### PR TITLE
Updated base urls.py

### DIFF
--- a/gsl_fantasy_tournament/gsl_fantasy_tournament/urls.py
+++ b/gsl_fantasy_tournament/gsl_fantasy_tournament/urls.py
@@ -20,5 +20,5 @@ from django.urls import include, path
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('home.urls')),
-    path('tourneys/<str:date>', include('tournament.urls'))
+    path('tournaments/<str:date>', include('tournament.urls'))
 ]


### PR DESCRIPTION
changed the urls <str:date> to tourneys/<str:date> to get rid of the error, as it would appear every time when one pretty much went anywhere on the site as it would check the date in the url, which kept flagging the error that falvicon.ico (the admin page icon renderer im guessing) was not in the form of the date.  


On a side note we maybe should change how we get to the tournaments as dates can be the same but that probably not too important unless this bot is going to be used for multiple tournaments. 

![image](https://github.com/Peders123/gsl-fantasy-tournament-manager/assets/72077134/bc3badcd-288a-4b0b-a1f3-892a978133ea)
