### PR TITLE
Create-slots-for-captains

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: terra:1.0
     ports:
       - "8000:8000"
+    volumes:
+      - ../athena/mount:/data/terra/mount
 
   mercury:
     build:

--- a/terra/auction/consumers.py
+++ b/terra/auction/consumers.py
@@ -17,11 +17,13 @@ class AuctionConsumer(AsyncWebsocketConsumer):
 
         captain = await self.get_captain_user()
         username = captain.smite_name
+        team_name = captain.team_name
 
         await self.channel_layer.group_send(
             self.room_group_name, {
                 'type': 'connection',
-                'user': username
+                'user': username,
+                'teamName': team_name
             }
         )
 
@@ -48,11 +50,10 @@ class AuctionConsumer(AsyncWebsocketConsumer):
 
     async def connection(self, event):
 
-        user = event['user']
-
         await self.send(text_data=json.dumps({
             'type': 'connection',
-            'user': user
+            'user': event['user'],
+            'teamName': event['teamName']
         }))
 
     async def message(self, event):

--- a/terra/auction/consumers.py
+++ b/terra/auction/consumers.py
@@ -15,9 +15,9 @@ class AuctionConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_add(self.room_group_name, self.channel_name)
         await self.accept()
 
-        captain = await self.get_captain_user()
-        username = captain.smite_name
-        team_name = captain.team_name
+        self.captain = await self.get_captain_user()
+        username = self.captain.smite_name
+        team_name = self.captain.team_name
 
         await self.channel_layer.group_send(
             self.room_group_name, {
@@ -28,6 +28,14 @@ class AuctionConsumer(AsyncWebsocketConsumer):
         )
 
     async def disconnect(self, code):
+
+        await self.channel_layer.group_send(
+            self.room_group_name, {
+                'type': 'disconnection',
+                'user': self.captain.smite_name,
+                'teamName': self.captain.team_name
+            }
+        )
 
         await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
 
@@ -52,6 +60,14 @@ class AuctionConsumer(AsyncWebsocketConsumer):
 
         await self.send(text_data=json.dumps({
             'type': 'connection',
+            'user': event['user'],
+            'teamName': event['teamName']
+        }))
+
+    async def disconnection(self, event):
+
+        await self.send(text_data=json.dumps({
+            'type': 'disconnection',
             'user': event['user'],
             'teamName': event['teamName']
         }))

--- a/terra/auction/consumers.py
+++ b/terra/auction/consumers.py
@@ -3,7 +3,7 @@ import json
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 
-from .models import Bidder, Biddee
+from .models import Bidder
 from tournament.models import Tournament, Captain
 
 
@@ -99,7 +99,7 @@ class AuctionConsumer(AsyncWebsocketConsumer):
         return Captain.objects.filter(
             user_id=self.scope['session']['discord']['id']
         )[0]
-    
+
     @sync_to_async
     def get_bidder(self):
 
@@ -111,7 +111,7 @@ class AuctionConsumer(AsyncWebsocketConsumer):
         if bidder.exists():
             return bidder[0]
         return None
-    
+
     @sync_to_async
     def create_bidder(self):
 
@@ -126,7 +126,7 @@ class AuctionConsumer(AsyncWebsocketConsumer):
         bidder.save()
 
         return bidder
-    
+
     @sync_to_async
     def set_bidder_in(self, currently_in):
 

--- a/terra/auction/models.py
+++ b/terra/auction/models.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+from tournament.models import Tournament, Captain, Player
+
+
+class Bidder(models.Model):
+
+    bidder_id = models.AutoField(primary_key=True)
+    tournament_id = models.ForeignKey(Tournament, on_delete=models.CASCADE)
+    captain_id = models.ForeignKey(Captain, on_delete=models.CASCADE)
+    join_order = models.IntegerField()
+    currently_in = models.BooleanField()
+
+
+class Biddee(models.Model):
+
+    biddee_id = models.AutoField(primary_key=True)
+    bidder_id = models.ForeignKey(Bidder, on_delete=models.CASCADE)
+    tournament_id = models.ForeignKey(Tournament, on_delete=models.CASCADE)
+    player_id = models.ForeignKey(Player, on_delete=models.CASCADE)
+    bidded_amount = models.IntegerField()
+    draft_order = models.IntegerField()

--- a/terra/auction/routing.py
+++ b/terra/auction/routing.py
@@ -3,5 +3,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r"ws/auction/auction", consumers.AuctionConsumer.as_asgi()),
+    re_path(r"ws/(?P<tournament_id>\w+)/auction", consumers.AuctionConsumer.as_asgi()),
 ]

--- a/terra/auction/templates/auction/room.html
+++ b/terra/auction/templates/auction/room.html
@@ -2,12 +2,78 @@
 <html>
 <head>
     <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Auction Room</title>
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .grid-container {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            grid-template-rows: repeat(4, 1fr);
+            gap: 2px;
+            flex-grow: 1;
+        }
+
+        .grid-item {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: lightgrey;
+            border: 1px solid black;
+        }
+
+        .buttons-container {
+            display: flex;
+            justify-content: center;
+            padding: 10px;
+        }
+
+        button {
+            margin: 0 5px;
+        }
+    </style>
 </head>
 <body>
-    <textarea id="chat-log" cols="100" rows="20"></textarea><br>
-    <input id="chat-message-input" type="text" size="100"><br>
-    <input id="chat-message-submit" type="button" value="Send">
+    <div class="grid-container">
+    </div>
+        <button id="turnRedButton">Turn Box Red</button>
+        <button id="turnGreyButton">Turn Box Grey</button>
+    <script>
+        // Create the grid items
+        const gridContainer = document.querySelector('.grid-container');
+        for (let i = 0; i < 16; i++) {
+            const gridItem = document.createElement('div');
+            gridItem.classList.add('grid-item');
+            gridContainer.appendChild(gridItem);
+        }
+
+        // JavaScript to handle the button clicks
+        const turnRedButton = document.getElementById('turnRedButton');
+        const turnGreyButton = document.getElementById('turnGreyButton');
+        let currentIndex = 0;
+
+        turnRedButton.addEventListener('click', () => {
+            const gridItems = document.querySelectorAll('.grid-item');
+            if (currentIndex < gridItems.length) {
+                gridItems[currentIndex].style.backgroundColor = 'red';
+                currentIndex++;
+            }
+        });
+
+        turnGreyButton.addEventListener('click', () => {
+            const gridItems = document.querySelectorAll('.grid-item');
+            if (currentIndex > 0) {
+                currentIndex--;
+                gridItems[currentIndex].style.backgroundColor = 'lightgrey';
+            }
+        });
+    </script>
     <script>
         console.log(window.location.host);
 

--- a/terra/auction/templates/auction/room.html
+++ b/terra/auction/templates/auction/room.html
@@ -66,8 +66,12 @@
 <body>
     <div class="grid-container">
     </div>
+
+    {{ bidders|json_script:"bidders" }}
+
     <script>
         const gridContainer = document.querySelector('.grid-container');
+        const bidders = JSON.parse(document.getElementById('bidders').textContent);
 
         function createPlayer(playerName) {
             const player = document.createElement('div');
@@ -100,10 +104,19 @@
             return gridItem;
         }
 
+        console.log(bidders.length);
+
+        bidders.forEach(bidder => {
+            console.log("Hello World");
+            console.log(bidder.username);
+            console.log(bidder.team_name);
+            gridContainer.appendChild(createGridItem(bidder.username, bidder.team_name));
+        })
+
         const chatSocket = new WebSocket(
             'ws://'
             + window.location.host
-            + '/ws/auction/auction'
+            + '/ws/1/auction'
         );
 
         chatSocket.onmessage = function(e) {

--- a/terra/auction/templates/auction/room.html
+++ b/terra/auction/templates/auction/room.html
@@ -68,7 +68,6 @@
     </div>
     <script>
         const gridContainer = document.querySelector('.grid-container');
-        let teamCount = 0;
 
         function createPlayer(playerName) {
             const player = document.createElement('div');
@@ -79,6 +78,7 @@
         
         function createGridItem(captainName, teamName) {
             const gridItem = document.createElement('div');
+            gridItem.id = captainName + ":" + teamName;
             gridItem.classList.add('grid-item');
 
             const teamNameContainer = document.createElement('div');
@@ -111,8 +111,11 @@
             switch (data.type) {
                 case "connection":
                     console.log("Captain joining: " + data.user);
-                    teamCount++;
                     gridContainer.appendChild(createGridItem(data.user, data.teamName));
+                    break;
+                case "disconnection":
+                    console.log("Captain leaving: " + data.user);
+                    gridContainer.removeChild(document.getElementById(data.user + ":" + data.teamName));
                     break;
             }
         };

--- a/terra/auction/templates/auction/room.html
+++ b/terra/auction/templates/auction/room.html
@@ -7,75 +7,98 @@
     <style>
         html, body {
             height: 100%;
+            width: 100%;
             margin: 0;
+            padding: 0;
             display: flex;
             flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
+            box-sizing: border-box; /* Ensure padding and border are included in the width */
         }
-
         .grid-container {
             display: grid;
             grid-template-columns: repeat(4, 1fr);
-            grid-template-rows: repeat(4, 1fr);
-            gap: 2px;
-            flex-grow: 1;
+            grid-template-rows: repeat(4, auto);
+            gap: 10px;
+            margin: 20px;
+            width: 80%; /* Set to 100% to span the full width of the viewport */
+            box-sizing: border-box; /* Ensure padding and border are included in the width */
         }
-
         .grid-item {
             display: flex;
-            align-items: center;
-            justify-content: center;
+            flex-direction: column;
             background-color: lightgrey;
             border: 1px solid black;
+            box-sizing: border-box; /* Ensure padding and border are included in the width */
         }
-
+        .team-name {
+            background-color: lightblue;
+            border-bottom: 1px solid black;
+            padding: 2ch 0ch;
+            border: 1px solid black;
+            text-align: center;
+            font-weight: bold;
+        }
+        .player-container {
+            display: flex;
+            border: 1px solid black;
+            flex-direction: column;
+            flex-grow: 1;
+        }
+        .player {
+            flex: 1;
+            background-color: white;
+            padding: 1.5ch 0ch;
+            text-align: center;
+            box-sizing: border-box; /* Ensure padding and border are included in the width */
+        }
         .buttons-container {
             display: flex;
             justify-content: center;
             padding: 10px;
         }
-
         button {
             margin: 0 5px;
-        }
+        }  margin: 0 5px;
     </style>
 </head>
 <body>
     <div class="grid-container">
     </div>
-        <button id="turnRedButton">Turn Box Red</button>
-        <button id="turnGreyButton">Turn Box Grey</button>
     <script>
-        // Create the grid items
         const gridContainer = document.querySelector('.grid-container');
-        for (let i = 0; i < 16; i++) {
+        let teamCount = 0;
+
+        function createPlayer(playerName) {
+            const player = document.createElement('div');
+            player.classList.add('player');
+            player.textContent = playerName;
+            return player;
+        }
+        
+        function createGridItem(captainName, teamName) {
             const gridItem = document.createElement('div');
             gridItem.classList.add('grid-item');
-            gridContainer.appendChild(gridItem);
+
+            const teamNameContainer = document.createElement('div');
+            teamNameContainer.classList.add('team-name');
+            teamNameContainer.textContent = teamName;
+            gridItem.appendChild(teamNameContainer);
+
+            const playerContainer = document.createElement('div');
+            playerContainer.classList.add('player-container');
+
+            playerContainer.appendChild(createPlayer(captainName));
+
+            for (let j = 1; j < 5; j++) {
+                playerContainer.appendChild(createPlayer(`Player ${j}`));
+            }
+
+            gridItem.appendChild(playerContainer);
+
+            return gridItem;
         }
-
-        // JavaScript to handle the button clicks
-        const turnRedButton = document.getElementById('turnRedButton');
-        const turnGreyButton = document.getElementById('turnGreyButton');
-        let currentIndex = 0;
-
-        turnRedButton.addEventListener('click', () => {
-            const gridItems = document.querySelectorAll('.grid-item');
-            if (currentIndex < gridItems.length) {
-                gridItems[currentIndex].style.backgroundColor = 'red';
-                currentIndex++;
-            }
-        });
-
-        turnGreyButton.addEventListener('click', () => {
-            const gridItems = document.querySelectorAll('.grid-item');
-            if (currentIndex > 0) {
-                currentIndex--;
-                gridItems[currentIndex].style.backgroundColor = 'lightgrey';
-            }
-        });
-    </script>
-    <script>
-        console.log(window.location.host);
 
         const chatSocket = new WebSocket(
             'ws://'
@@ -87,10 +110,9 @@
             const data = JSON.parse(e.data);
             switch (data.type) {
                 case "connection":
-                    document.querySelector('#chat-log').value += ("User: " + data.user + " has connected.\n");
-                    break;
-                case "message":
-                    document.querySelector('#chat-log').value += (data.message + '\n');
+                    console.log("Captain joining: " + data.user);
+                    teamCount++;
+                    gridContainer.appendChild(createGridItem(data.user, data.teamName));
                     break;
             }
         };
@@ -99,22 +121,6 @@
             console.error('Chat socket closed unexpectedly');
         };
 
-        document.querySelector('#chat-message-input').focus();
-        document.querySelector('#chat-message-input').onkeyup = function(e) {
-            if (e.key === 'Enter') {  // enter, return
-                document.querySelector('#chat-message-submit').click();
-            }
-        };
-
-        document.querySelector('#chat-message-submit').onclick = function(e) {
-            const messageInputDom = document.querySelector('#chat-message-input');
-            const message = messageInputDom.value;
-            chatSocket.send(JSON.stringify({
-                'type': 'message',
-                'message': message
-            }));
-            messageInputDom.value = '';
-        };
     </script>
 </body>
 </html>

--- a/terra/auction/views.py
+++ b/terra/auction/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
+from .models import Bidder
 from tournament.models import Captain
 
 
@@ -26,5 +27,23 @@ def room(request, room_name):
         url = reverse('auction')
         error = "User is not registered as a captain."
         return redirect(f"{url}?errno=401&error={error}")
+    
+    bidders = Bidder.objects.filter(
+        tournament_id=1,
+        currently_in=True
+    ).order_by('join_order')
 
-    return render(request, 'auction/room.html', {'room_name': room_name})
+    print(len(bidders))
+
+    bidders_list = [
+        {
+            'username': bidder.captain_id.smite_name,
+            'team_name': bidder.captain_id.team_name
+        }
+        for bidder in bidders
+    ]
+
+    return render(request, 'auction/room.html', {
+        'room_name': room_name,
+        'bidders': bidders_list
+    })

--- a/terra/auction/views.py
+++ b/terra/auction/views.py
@@ -27,7 +27,7 @@ def room(request, room_name):
         url = reverse('auction')
         error = "User is not registered as a captain."
         return redirect(f"{url}?errno=401&error={error}")
-    
+
     bidders = Bidder.objects.filter(
         tournament_id=1,
         currently_in=True

--- a/terra/home/templates/home/home.html
+++ b/terra/home/templates/home/home.html
@@ -14,6 +14,4 @@
     {% for tournament in tournaments %}
         <p>{{ tournament.title }}</p>
     {% endfor %}
-    
 </body>
-

--- a/terra/startTerra.sh
+++ b/terra/startTerra.sh
@@ -2,6 +2,10 @@
 
 cd /data/terra
 
+python3 manage.py makemigrations auction
+python3 manage.py migrate auction
+
+
 python3 manage.py makemigrations
 python3 manage.py migrate
 python3 manage.py collectstatic

--- a/terra/terra/settings.py
+++ b/terra/terra/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 import json
 import os
+import sys
 from pathlib import Path
 
 with open(os.path.join('secrets.json')) as secrets:
@@ -18,6 +19,17 @@ with open(os.path.join('secrets.json')) as secrets:
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Define the path to your custom migrations
+MIGRATIONS_PATH = Path("/data/terra/mount/terra/migrations")
+
+# Add the custom migrations path to the system path
+sys.path.append(str(MIGRATIONS_PATH))
+
+MIGRATION_MODULES = {
+    'auction': 'mount.terra.migrations',
+}
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/


### PR DESCRIPTION
Loads the captains in the auction page per captain joining.

When a new person joins the room, loads all previously joined captains as well.

More testing is needed in order to see if the captain joining order is maintained here.

Currently, this is hardcoded to only accept tournament 1. This MUST be changed by whoever merges this functionality into the base-page.