### PR TITLE
Janus/TSL-3_Make_context_serializable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ secrets.json
 .venv
 .pylintrc
 .ser
+.log
 environment.sh
 
 migrations

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ secrets.json
 .vscode
 .venv
 .pylintrc
+.ser
 environment.sh
 
 migrations

--- a/athena/logs/janus.log
+++ b/athena/logs/janus.log
@@ -1,5 +1,0 @@
-2024-08-25 14:21:31 [main] INFO  FileLogger - Commands created
-2024-08-25 14:51:20 [main] INFO  FileLogger - Commands created
-2024-08-25 14:53:02 [main] INFO  FileLogger - Commands created
-2024-08-25 14:55:43 [main] INFO  FileLogger - Commands created
-2024-08-25 15:00:37 [App.java:107] INFO  FileLogger - Commands created {main}

--- a/janus/src/main/java/com/tanukismite/fantasy/bot/App.java
+++ b/janus/src/main/java/com/tanukismite/fantasy/bot/App.java
@@ -60,7 +60,7 @@ public class App {
         JDA jda = build.enableIntents(GatewayIntent.MESSAGE_CONTENT)
             .build();
 
-        Handler handler = new Handler();
+        Handler handler = new Handler(jda);
         jda.addEventListener(new ButtonListener(handler));
         jda.addEventListener(new ModalListener(handler));
         jda.addEventListener(new SlashCommandListener(handler));

--- a/janus/src/main/java/com/tanukismite/fantasy/bot/commands/Context.java
+++ b/janus/src/main/java/com/tanukismite/fantasy/bot/commands/Context.java
@@ -6,14 +6,29 @@ import com.tanukismite.fantasy.bot.commands.slash_commands.CreateSignups;
 import com.tanukismite.fantasy.bot.commands.slash_commands.CreateTournament;
 import com.tanukismite.fantasy.bot.signup.SignupData;
 
+import net.dv8tion.jda.api.JDA;
+
 public class Context {
 
     private ConcurrentHashMap<String, SignupData> userSignupSessions;
     private CreateSignups signupRoot;
     private CreateTournament tournamentRoot;
 
-    public Context() {
+    public Context(JDA jda) {
         this.userSignupSessions = new ConcurrentHashMap<>();
+        this.signupRoot = this.initialiseSignupRoot(jda);
+    }
+
+    private CreateSignups initialiseSignupRoot(JDA jda) {
+
+        CreateSignups signups = CreateSignups.readObject();
+        if (signups == null) {
+            return null;
+        }
+        signups.initialiseNonSerializedFields(jda);
+
+        return signups;
+
     }
 
     public <T extends SignupData> T getUserSignupData(String id, Class<T> type) {

--- a/janus/src/main/java/com/tanukismite/fantasy/bot/handlers/Handler.java
+++ b/janus/src/main/java/com/tanukismite/fantasy/bot/handlers/Handler.java
@@ -6,13 +6,15 @@ import com.tanukismite.fantasy.bot.commands.Command;
 import com.tanukismite.fantasy.bot.commands.Context;
 import com.tanukismite.fantasy.bot.communicators.MercuryCommunicator;
 
+import net.dv8tion.jda.api.JDA;
+
 public class Handler {
 
     private Context context;
     private HashMap<String, MercuryCommunicator> communicators;
 
-    public Handler() {
-        this.context = new Context();
+    public Handler(JDA jda) {
+        this.context = new Context(jda);
         this.communicators = new HashMap<>();
     }
 


### PR DESCRIPTION
Scope of the ticket was adjusted as progress was made. For now, the only command with a persistent state is CreateSignups, so that is the only one being currently serialized.

When the program runs, it loads the previous state from a .ser file, stored in a docker volume.

This currently supports only 1 instance of Signups existent at one time. Allowing support for more, as well as other persistent commands in general would require a higher level system redesign. However, this command will be put on the back bench for now as it will be un-needed for the upcoming events soon.

This implementation was done by extracting out the non-serializable attributes into serializable components, and then deriving the non-serializable components into it once again.